### PR TITLE
Add pill-app FastAPI project scaffold

### DIFF
--- a/pill-app/.gitignore
+++ b/pill-app/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.pyc
+db/app.sqlite
+data/raw/*
+!data/raw/.gitignore
+data/outputs/*
+!data/outputs/.gitignore

--- a/pill-app/README.md
+++ b/pill-app/README.md
@@ -1,0 +1,76 @@
+# pill-app
+
+Minimal FastAPI project for managing "pill bags" and their images.
+
+## Project structure
+
+```
+pill-app/
+├── data/
+│   ├── outputs/
+│   └── raw/
+├── db/
+├── src/
+│   ├── api.py
+│   ├── schemas.py
+│   └── store.py
+├── tests/
+├── README.md
+└── requirements.txt
+```
+
+The SQLite database file (`db/app.sqlite`) is created automatically on first run. Uploaded images are saved under `data/raw/`.
+
+## Setup
+
+```bash
+cd pill-app
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\\Scripts\\activate
+pip install -r requirements.txt
+```
+
+## Run the API
+
+```bash
+uvicorn src.api:app --reload
+```
+
+The service listens on `http://127.0.0.1:8000` by default.
+
+## Example requests
+
+Check health:
+
+```bash
+curl http://127.0.0.1:8000/health
+```
+
+Create a bag:
+
+```bash
+curl -X POST "http://127.0.0.1:8000/api/bags" \
+  -H "Content-Type: application/json" \
+  -d '{"label": "morning"}'
+```
+
+Upload an image to the bag (replace `<BAG_ID>` with the response from the previous command):
+
+```bash
+curl -X POST "http://127.0.0.1:8000/api/images?bag_id=<BAG_ID>" \
+  -F "file=@path/to/image.png"
+```
+
+List bag details with images:
+
+```bash
+curl http://127.0.0.1:8000/api/bags/<BAG_ID>
+```
+
+## Tests
+
+Run the pytest suite from the project root:
+
+```bash
+pytest
+```

--- a/pill-app/data/outputs/.gitignore
+++ b/pill-app/data/outputs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/pill-app/data/raw/.gitignore
+++ b/pill-app/data/raw/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/pill-app/db/.gitignore
+++ b/pill-app/db/.gitignore
@@ -1,0 +1,1 @@
+app.sqlite

--- a/pill-app/requirements.txt
+++ b/pill-app/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.110.0
+uvicorn[standard]==0.29.0
+pillow==10.2.0
+python-multipart==0.0.9
+pytest==8.1.1

--- a/pill-app/src/__init__.py
+++ b/pill-app/src/__init__.py
@@ -1,0 +1,1 @@
+# Makes src a package.

--- a/pill-app/src/api.py
+++ b/pill-app/src/api.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import uuid
+from io import BytesIO
+from pathlib import Path
+from typing import Optional
+
+from fastapi import Body, FastAPI, File, HTTPException, UploadFile
+from fastapi.params import Query
+from PIL import Image, UnidentifiedImageError
+
+from . import schemas, store
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+RAW_DIR = BASE_DIR / "data" / "raw"
+RAW_DIR.mkdir(parents=True, exist_ok=True)
+
+app = FastAPI(title="pill-app")
+
+
+@app.get("/health")
+def health_check() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.post("/api/bags", response_model=schemas.Bag)
+def create_bag(payload: Optional[schemas.BagCreate] = Body(default=None)) -> schemas.Bag:
+    label = payload.label if payload else None
+    bag = store.create_bag(label)
+    return schemas.Bag(**bag)
+
+
+@app.post("/api/images", response_model=schemas.Image)
+async def upload_image(
+    bag_id: str = Query(..., description="Identifier of the bag that owns the image"),
+    file: UploadFile = File(...),
+) -> schemas.Image:
+    bag = store.get_bag_basic(bag_id)
+    if bag is None:
+        raise HTTPException(status_code=404, detail="Bag not found")
+
+    contents = await file.read()
+    if not contents:
+        raise HTTPException(status_code=400, detail="Uploaded file is empty")
+
+    try:
+        pil_image = Image.open(BytesIO(contents))
+        pil_image.load()
+        width, height = pil_image.size
+    except (UnidentifiedImageError, OSError) as exc:
+        raise HTTPException(status_code=400, detail="Invalid image file") from exc
+
+    suffix = Path(file.filename or "").suffix
+    if not suffix:
+        suffix = ".png"
+    filename = f"{uuid.uuid4()}{suffix}"
+    file_path = RAW_DIR / filename
+    with open(file_path, "wb") as output:
+        output.write(contents)
+
+    relative_path = str(file_path.relative_to(BASE_DIR))
+    record = store.create_image(bag_id=bag_id, path=relative_path, width=width, height=height)
+    return schemas.Image(**record)
+
+
+@app.get("/api/bags/{bag_id}", response_model=schemas.BagWithImages)
+def get_bag(bag_id: str) -> schemas.BagWithImages:
+    bag = store.get_bag(bag_id)
+    if bag is None:
+        raise HTTPException(status_code=404, detail="Bag not found")
+    return schemas.BagWithImages(**bag)

--- a/pill-app/src/schemas.py
+++ b/pill-app/src/schemas.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class BagCreate(BaseModel):
+    label: Optional[str] = None
+
+
+class Image(BaseModel):
+    id: str
+    bag_id: str
+    path: str
+    width: int
+    height: int
+    created_at: str
+
+
+class Bag(BaseModel):
+    id: str
+    label: Optional[str] = None
+    created_at: str
+
+
+class BagWithImages(Bag):
+    images: List[Image] = Field(default_factory=list)

--- a/pill-app/src/store.py
+++ b/pill-app/src/store.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import sqlite3
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+DB_DIR = BASE_DIR / "db"
+DB_DIR.mkdir(parents=True, exist_ok=True)
+DB_PATH = DB_DIR / "app.sqlite"
+
+
+def get_connection() -> sqlite3.Connection:
+    """Return a SQLite connection with sensible defaults."""
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON;")
+    return conn
+
+
+def init_db() -> None:
+    """Ensure the database schema exists."""
+    conn = get_connection()
+    try:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS bags (
+                id TEXT PRIMARY KEY,
+                label TEXT,
+                created_at TEXT NOT NULL
+            );
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS images (
+                id TEXT PRIMARY KEY,
+                bag_id TEXT NOT NULL,
+                path TEXT NOT NULL,
+                width INTEGER NOT NULL,
+                height INTEGER NOT NULL,
+                created_at TEXT NOT NULL,
+                FOREIGN KEY (bag_id) REFERENCES bags(id) ON DELETE CASCADE
+            );
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+init_db()
+
+
+def create_bag(label: Optional[str]) -> Dict[str, object]:
+    """Create a new bag entry and return its data."""
+    bag_id = str(uuid.uuid4())
+    now = datetime.utcnow().isoformat()
+    conn = get_connection()
+    try:
+        conn.execute(
+            "INSERT INTO bags (id, label, created_at) VALUES (?, ?, ?)",
+            (bag_id, label, now),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return {"id": bag_id, "label": label, "created_at": now}
+
+
+def get_bag_basic(bag_id: str) -> Optional[Dict[str, object]]:
+    """Fetch a bag without loading its images."""
+    conn = get_connection()
+    try:
+        cursor = conn.execute(
+            "SELECT id, label, created_at FROM bags WHERE id = ?",
+            (bag_id,),
+        )
+        row = cursor.fetchone()
+        if row is None:
+            return None
+        return dict(row)
+    finally:
+        conn.close()
+
+
+def list_bag_images(bag_id: str) -> List[Dict[str, object]]:
+    """List images belonging to a bag."""
+    conn = get_connection()
+    try:
+        cursor = conn.execute(
+            """
+            SELECT id, bag_id, path, width, height, created_at
+            FROM images
+            WHERE bag_id = ?
+            ORDER BY created_at ASC
+            """,
+            (bag_id,),
+        )
+        return [dict(row) for row in cursor.fetchall()]
+    finally:
+        conn.close()
+
+
+def get_bag(bag_id: str) -> Optional[Dict[str, object]]:
+    """Fetch a bag with its associated images."""
+    bag = get_bag_basic(bag_id)
+    if bag is None:
+        return None
+    bag["images"] = list_bag_images(bag_id)
+    return bag
+
+
+def create_image(bag_id: str, path: str, width: int, height: int) -> Dict[str, object]:
+    """Create an image record linked to a bag."""
+    image_id = str(uuid.uuid4())
+    now = datetime.utcnow().isoformat()
+    conn = get_connection()
+    try:
+        conn.execute(
+            """
+            INSERT INTO images (id, bag_id, path, width, height, created_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (image_id, bag_id, path, width, height, now),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return {
+        "id": image_id,
+        "bag_id": bag_id,
+        "path": path,
+        "width": width,
+        "height": height,
+        "created_at": now,
+    }

--- a/pill-app/tests/test_api.py
+++ b/pill-app/tests/test_api.py
@@ -1,0 +1,59 @@
+import io
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+from PIL import Image
+
+from src.api import app
+
+client = TestClient(app)
+BASE_DIR = Path(__file__).resolve().parents[1]
+
+
+def create_image_bytes(size: tuple[int, int] = (32, 16), color: str = "blue") -> bytes:
+    image = Image.new("RGB", size, color=color)
+    buffer = io.BytesIO()
+    image.save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+def test_health_check() -> None:
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_create_bag() -> None:
+    response = client.post("/api/bags", json={"label": "morning"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"]
+    assert data["label"] == "morning"
+    assert "created_at" in data
+
+
+def test_upload_image_and_list() -> None:
+    bag_response = client.post("/api/bags", json={"label": "images"})
+    bag_response.raise_for_status()
+    bag_id = bag_response.json()["id"]
+
+    image_bytes = create_image_bytes()
+    files = {"file": ("test.png", image_bytes, "image/png")}
+
+    upload_response = client.post("/api/images", params={"bag_id": bag_id}, files=files)
+    assert upload_response.status_code == 200
+    image_data = upload_response.json()
+    assert image_data["bag_id"] == bag_id
+    assert image_data["width"] == 32
+    assert image_data["height"] == 16
+
+    stored_path = BASE_DIR / image_data["path"]
+    assert stored_path.exists()
+
+    bag_detail = client.get(f"/api/bags/{bag_id}")
+    assert bag_detail.status_code == 200
+    bag_data = bag_detail.json()
+    assert bag_data["id"] == bag_id
+    assert bag_data["label"] == "images"
+    assert len(bag_data["images"]) == 1
+    assert bag_data["images"][0]["id"] == image_data["id"]


### PR DESCRIPTION
## Summary
- add a FastAPI application that exposes health, bag, and image endpoints with image persistence under `data/raw`
- implement a SQLite-backed store module and Pydantic schemas to manage bags and their images
- document setup and usage while adding pytest coverage for the core API flows

## Testing
- pip install -r requirements.txt *(fails: proxy prevents downloading fastapi)*
- pytest *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68cb88f15478832c83e5c0d513bfb088