### PR TITLE
Add pill detection pipeline with visualization and API support

### DIFF
--- a/pill-app/requirements.txt
+++ b/pill-app/requirements.txt
@@ -3,3 +3,4 @@ uvicorn[standard]==0.29.0
 pillow==10.2.0
 python-multipart==0.0.9
 pytest==8.1.1
+opencv-python-headless==4.9.0.80

--- a/pill-app/src/detect.py
+++ b/pill-app/src/detect.py
@@ -1,0 +1,171 @@
+"""Utility functions for basic pill detection using OpenCV."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Sequence, Tuple
+
+import cv2
+import numpy as np
+
+
+@dataclass(frozen=True)
+class Detection:
+    """Representation of a detected object."""
+
+    x1: int
+    y1: int
+    x2: int
+    y2: int
+    score: float
+
+    def as_dict(self) -> dict[str, float]:
+        return {"x1": self.x1, "y1": self.y1, "x2": self.x2, "y2": self.y2, "score": float(self.score)}
+
+
+@dataclass(frozen=True)
+class RegionFlag:
+    """Region flagged for manual review."""
+
+    x1: int
+    y1: int
+    x2: int
+    y2: int
+    reason: str
+
+    def as_dict(self) -> dict[str, object]:
+        return {"x1": self.x1, "y1": self.y1, "x2": self.x2, "y2": self.y2, "reason": self.reason}
+
+
+def _to_path(path: str | Path) -> Path:
+    return path if isinstance(path, Path) else Path(path)
+
+
+def _prepare_image(path: Path) -> Tuple[np.ndarray, Tuple[int, int]]:
+    image = cv2.imread(str(path))
+    if image is None:
+        raise FileNotFoundError(f"Unable to read image: {path}")
+    gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+    height, width = gray.shape[:2]
+    return gray, (height, width)
+
+
+def detect_pills(
+    image_path: str | Path,
+    blur_kernel_size: int = 5,
+    canny_thresholds: Tuple[int, int] = (40, 120),
+    min_area_ratio: float = 0.0005,
+    max_area_ratio: float = 0.6,
+    max_aspect_ratio: float = 6.0,
+) -> Tuple[List[dict[str, float]], Tuple[int, int]]:
+    """Detect pill-like contours in an image."""
+
+    path = _to_path(image_path)
+    gray, (height, width) = _prepare_image(path)
+
+    blur_kernel = (blur_kernel_size, blur_kernel_size)
+    blurred = cv2.GaussianBlur(gray, blur_kernel, 0)
+    edges = cv2.Canny(blurred, canny_thresholds[0], canny_thresholds[1])
+    kernel = np.ones((3, 3), np.uint8)
+    edges = cv2.dilate(edges, kernel, iterations=1)
+    edges = cv2.erode(edges, kernel, iterations=1)
+
+    contours, _ = cv2.findContours(edges, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+
+    image_area = float(height * width)
+    detections: List[Detection] = []
+    for contour in contours:
+        area = cv2.contourArea(contour)
+        if area <= 0:
+            continue
+        area_ratio = area / image_area
+        if area_ratio < min_area_ratio or area_ratio > max_area_ratio:
+            continue
+
+        x, y, w_box, h_box = cv2.boundingRect(contour)
+        if w_box < 5 or h_box < 5:
+            continue
+
+        aspect_ratio = max(w_box, h_box) / max(1, min(w_box, h_box))
+        if aspect_ratio > max_aspect_ratio:
+            continue
+
+        perimeter = cv2.arcLength(contour, True)
+        circularity = 0.0
+        if perimeter > 0:
+            circularity = float((4 * np.pi * area) / (perimeter * perimeter))
+        box_area = float(w_box * h_box)
+        fill_ratio = area / box_area if box_area else 0.0
+
+        norm_area = min(1.0, area_ratio / 0.05)
+        fill_score = min(1.0, fill_ratio)
+        aspect_score = max(0.0, 1.0 - (aspect_ratio - 1.0) / 4.0)
+        circularity_score = min(1.0, circularity)
+        raw_score = 0.35 * fill_score + 0.25 * aspect_score + 0.2 * norm_area + 0.2 * circularity_score
+        score = max(0.0, min(1.0, raw_score))
+
+        detections.append(Detection(x, y, x + w_box, y + h_box, round(score, 3)))
+
+    detections.sort(key=lambda det: det.score, reverse=True)
+    return [det.as_dict() for det in detections], (height, width)
+
+
+def _intersection_over_union(a: Detection | dict[str, float], b: Detection | dict[str, float]) -> float:
+    ax1, ay1, ax2, ay2 = int(a["x1"]), int(a["y1"]), int(a["x2"]), int(a["y2"])
+    bx1, by1, bx2, by2 = int(b["x1"]), int(b["y1"]), int(b["x2"]), int(b["y2"])
+
+    inter_x1 = max(ax1, bx1)
+    inter_y1 = max(ay1, by1)
+    inter_x2 = min(ax2, bx2)
+    inter_y2 = min(ay2, by2)
+
+    if inter_x2 <= inter_x1 or inter_y2 <= inter_y1:
+        return 0.0
+
+    inter_area = float((inter_x2 - inter_x1) * (inter_y2 - inter_y1))
+    area_a = float((ax2 - ax1) * (ay2 - ay1))
+    area_b = float((bx2 - bx1) * (by2 - by1))
+    union_area = area_a + area_b - inter_area
+    if union_area <= 0:
+        return 0.0
+    return inter_area / union_area
+
+
+def identify_unrecognized_regions(
+    detections: Sequence[dict[str, float]],
+    image_size: Tuple[int, int],
+    low_score_threshold: float = 0.45,
+    cluster_iou_threshold: float = 0.4,
+) -> Tuple[List[dict[str, object]], str | None]:
+    """Identify regions that require manual verification."""
+
+    height, width = image_size
+    flags: List[RegionFlag] = []
+
+    for det in detections:
+        if det["score"] < low_score_threshold:
+            flags.append(RegionFlag(int(det["x1"]), int(det["y1"]), int(det["x2"]), int(det["y2"]), "low_score"))
+
+    clustered: set[Tuple[int, int, int, int]] = set()
+    for i in range(len(detections)):
+        for j in range(i + 1, len(detections)):
+            det_a, det_b = detections[i], detections[j]
+            iou = _intersection_over_union(det_a, det_b)
+            if iou >= cluster_iou_threshold:
+                x1 = min(int(det_a["x1"]), int(det_b["x1"]))
+                y1 = min(int(det_a["y1"]), int(det_b["y1"]))
+                x2 = max(int(det_a["x2"]), int(det_b["x2"]))
+                y2 = max(int(det_a["y2"]), int(det_b["y2"]))
+                clustered.add((x1, y1, x2, y2))
+
+    for x1, y1, x2, y2 in clustered:
+        flags.append(RegionFlag(x1, y1, x2, y2, "clustered"))
+
+    message: str | None = None
+    if not detections:
+        flags.append(RegionFlag(0, 0, width, height, "no_detections"))
+        message = "検出に失敗しました。再解析が必要です。"
+    elif flags:
+        message = "一部の領域で再解析を推奨します。"
+
+    return [flag.as_dict() for flag in flags], message

--- a/pill-app/src/schemas.py
+++ b/pill-app/src/schemas.py
@@ -18,6 +18,24 @@ class Image(BaseModel):
     created_at: str
 
 
+class Detection(BaseModel):
+    id: Optional[int] = None
+    image_id: str
+    x1: int
+    y1: int
+    x2: int
+    y2: int
+    score: float
+
+
+class RegionFlag(BaseModel):
+    x1: int
+    y1: int
+    x2: int
+    y2: int
+    reason: str
+
+
 class Bag(BaseModel):
     id: str
     label: Optional[str] = None
@@ -26,3 +44,11 @@ class Bag(BaseModel):
 
 class BagWithImages(Bag):
     images: List[Image] = Field(default_factory=list)
+
+
+class ImageDetections(BaseModel):
+    image: Image
+    detections: List[Detection] = Field(default_factory=list)
+    visualization_path: str
+    unrecognized_regions: List[RegionFlag] = Field(default_factory=list)
+    message: Optional[str] = None

--- a/pill-app/src/store.py
+++ b/pill-app/src/store.py
@@ -4,7 +4,7 @@ import sqlite3
 import uuid
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, Iterable, List, Optional
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 DB_DIR = BASE_DIR / "db"
@@ -43,6 +43,20 @@ def init_db() -> None:
                 height INTEGER NOT NULL,
                 created_at TEXT NOT NULL,
                 FOREIGN KEY (bag_id) REFERENCES bags(id) ON DELETE CASCADE
+            );
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS detections (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                image_id TEXT NOT NULL,
+                x1 INTEGER NOT NULL,
+                y1 INTEGER NOT NULL,
+                x2 INTEGER NOT NULL,
+                y2 INTEGER NOT NULL,
+                score REAL NOT NULL,
+                FOREIGN KEY (image_id) REFERENCES images(id) ON DELETE CASCADE
             );
             """
         )
@@ -113,6 +127,27 @@ def get_bag(bag_id: str) -> Optional[Dict[str, object]]:
     return bag
 
 
+def get_image(image_id: str) -> Optional[Dict[str, object]]:
+    """Fetch an image record by its identifier."""
+
+    conn = get_connection()
+    try:
+        cursor = conn.execute(
+            """
+            SELECT id, bag_id, path, width, height, created_at
+            FROM images
+            WHERE id = ?
+            """,
+            (image_id,),
+        )
+        row = cursor.fetchone()
+        if row is None:
+            return None
+        return dict(row)
+    finally:
+        conn.close()
+
+
 def create_image(bag_id: str, path: str, width: int, height: int) -> Dict[str, object]:
     """Create an image record linked to a bag."""
     image_id = str(uuid.uuid4())
@@ -137,3 +172,50 @@ def create_image(bag_id: str, path: str, width: int, height: int) -> Dict[str, o
         "height": height,
         "created_at": now,
     }
+
+
+def replace_detections(image_id: str, detections: Iterable[Dict[str, object]]) -> None:
+    """Replace detections for an image with the provided records."""
+
+    conn = get_connection()
+    try:
+        conn.execute("DELETE FROM detections WHERE image_id = ?", (image_id,))
+        conn.executemany(
+            """
+            INSERT INTO detections (image_id, x1, y1, x2, y2, score)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    image_id,
+                    int(det["x1"]),
+                    int(det["y1"]),
+                    int(det["x2"]),
+                    int(det["y2"]),
+                    float(det["score"]),
+                )
+                for det in detections
+            ],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def list_detections(image_id: str) -> List[Dict[str, object]]:
+    """List detections stored for an image."""
+
+    conn = get_connection()
+    try:
+        cursor = conn.execute(
+            """
+            SELECT id, image_id, x1, y1, x2, y2, score
+            FROM detections
+            WHERE image_id = ?
+            ORDER BY score DESC, id ASC
+            """,
+            (image_id,),
+        )
+        return [dict(row) for row in cursor.fetchall()]
+    finally:
+        conn.close()

--- a/pill-app/src/visualize.py
+++ b/pill-app/src/visualize.py
@@ -1,0 +1,70 @@
+"""Visualization helpers for pill detection."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Sequence
+
+import cv2
+
+
+BLUE = (255, 0, 0)
+RED = (0, 0, 255)
+FONT = cv2.FONT_HERSHEY_SIMPLEX
+
+
+def visualization_path_for(image_id: str, output_dir: str | Path) -> Path:
+    """Return the canonical visualization path for an image id."""
+
+    directory = Path(output_dir)
+    directory.mkdir(parents=True, exist_ok=True)
+    return directory / f"{image_id}.png"
+
+
+def visualize_detections(
+    image_path: str | Path,
+    detections: Sequence[dict[str, float]],
+    unrecognized_regions: Sequence[dict[str, object]],
+    output_path: str | Path,
+) -> Path:
+    """Draw detections and flagged regions and save the visualization image."""
+
+    image_path = Path(image_path)
+    output_path = Path(output_path)
+
+    image = cv2.imread(str(image_path))
+    if image is None:
+        raise FileNotFoundError(f"Unable to read image: {image_path}")
+
+    canvas = image.copy()
+
+    for det in detections:
+        pt1 = (int(det["x1"]), int(det["y1"]))
+        pt2 = (int(det["x2"]), int(det["y2"]))
+        cv2.rectangle(canvas, pt1, pt2, BLUE, 2)
+        label = f"{det['score']:.2f}"
+        text_origin = (pt1[0], max(15, pt1[1] - 5))
+        cv2.putText(canvas, label, text_origin, FONT, 0.5, BLUE, 1, cv2.LINE_AA)
+
+    for region in unrecognized_regions:
+        pt1 = (int(region["x1"]), int(region["y1"]))
+        pt2 = (int(region["x2"]), int(region["y2"]))
+        cv2.rectangle(canvas, pt1, pt2, RED, 2)
+        reason = str(region.get("reason", "check"))
+        text_origin = (pt1[0], min(canvas.shape[0] - 5, pt2[1] + 15))
+        cv2.putText(canvas, reason, text_origin, FONT, 0.5, RED, 1, cv2.LINE_AA)
+
+    if not detections:
+        cv2.putText(
+            canvas,
+            "再解析が必要です",
+            (10, 30),
+            FONT,
+            0.8,
+            RED,
+            2,
+            cv2.LINE_AA,
+        )
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    cv2.imwrite(str(output_path), canvas)
+    return output_path


### PR DESCRIPTION
## Summary
- add OpenCV-based detection and visualization utilities to process uploaded images
- extend the FastAPI endpoints and database store with detection persistence and retrieval
- update schemas and tests to exercise the new detection workflow and visualization output

## Testing
- pytest *(fails: missing FastAPI dependency in the execution environment)*


------
https://chatgpt.com/codex/tasks/task_e_68cb90133870832c8a15244cb4c781f0