### PR TITLE
Add embedding pipeline with FAISS similarity scoring

### DIFF
--- a/pill-app/src/embed.py
+++ b/pill-app/src/embed.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+"""Embedding utilities for pill detections."""
+
+import logging
+from functools import lru_cache
+from typing import Iterable, Tuple
+
+import numpy as np
+from PIL import Image
+
+logger = logging.getLogger(__name__)
+
+try:  # pragma: no cover - optional dependency
+    import torch
+    from torchvision.models import ResNet18_Weights, resnet18
+except Exception as exc:  # pragma: no cover - executed when torch is absent
+    torch = None  # type: ignore[assignment]
+    ResNet18_Weights = None  # type: ignore[assignment]
+    resnet18 = None  # type: ignore[assignment]
+    _BACKEND_ERROR = exc
+else:  # pragma: no cover - exercised when torch is available
+    _BACKEND_ERROR = None
+
+EMBED_DIM = 512
+
+
+def _as_pil(image: Image.Image | np.ndarray) -> Image.Image:
+    """Convert various image representations to :class:`PIL.Image`."""
+
+    if isinstance(image, Image.Image):
+        return image
+    if isinstance(image, np.ndarray):
+        if image.ndim == 2:
+            mode = "L"
+        elif image.ndim == 3 and image.shape[2] == 1:
+            mode = "L"
+            image = image[:, :, 0]
+        else:
+            mode = "RGB"
+        return Image.fromarray(image.astype(np.uint8), mode=mode)
+    raise TypeError(f"Unsupported image type: {type(image)!r}")
+
+
+@lru_cache(maxsize=1)
+def _load_model() -> Tuple[object | None, object | None]:
+    """Load the ResNet18 backbone used for embeddings.
+
+    The model is lazily instantiated to avoid the heavy import cost when the
+    embedding endpoint is unused. If torch or torchvision are unavailable the
+    function logs a warning and returns ``(None, None)``, causing callers to
+    fall back to zero embeddings.
+    """
+
+    if torch is None or resnet18 is None or ResNet18_Weights is None:
+        if _BACKEND_ERROR is not None:
+            logger.warning("Embedding backend unavailable: %s", _BACKEND_ERROR)
+        else:
+            logger.warning("Embedding backend unavailable: torch/torchvision not installed")
+        return None, None
+
+    weights = ResNet18_Weights.IMAGENET1K_V1
+    try:
+        model = resnet18(weights=weights)
+    except Exception as exc:  # pragma: no cover - depends on runtime availability
+        logger.warning("Falling back to randomly initialised ResNet18: %s", exc)
+        model = resnet18(weights=None)
+    model.fc = torch.nn.Identity()
+    model.eval()
+    for param in model.parameters():  # type: ignore[assignment]
+        param.requires_grad_(False)
+    device = torch.device("cpu")
+    model.to(device)
+    transform = weights.transforms()
+    return model, transform
+
+
+def _zero_vector() -> np.ndarray:
+    return np.zeros(EMBED_DIM, dtype=np.float32)
+
+
+def embed_crop(image: Image.Image | np.ndarray, box: Iterable[float | int]) -> np.ndarray:
+    """Embed a cropped region of an image using ResNet18 features.
+
+    Parameters
+    ----------
+    image:
+        Source image either as a PIL image or a NumPy array.
+    box:
+        Bounding box ``(x1, y1, x2, y2)`` describing the crop.
+    """
+
+    pil_image = _as_pil(image).convert("RGB")
+    width, height = pil_image.size
+    x1, y1, x2, y2 = [int(float(coord)) for coord in box]
+    x1 = max(0, min(x1, width))
+    y1 = max(0, min(y1, height))
+    x2 = max(0, min(x2, width))
+    y2 = max(0, min(y2, height))
+
+    if x2 <= x1 or y2 <= y1:
+        logger.debug("Invalid crop bounds: (%s, %s, %s, %s)", x1, y1, x2, y2)
+        return _zero_vector()
+
+    crop = pil_image.crop((x1, y1, x2, y2))
+    if crop.size[0] == 0 or crop.size[1] == 0:
+        return _zero_vector()
+
+    model, transform = _load_model()
+    if model is None or transform is None:
+        return _zero_vector()
+
+    input_tensor = transform(crop).unsqueeze(0)
+    with torch.inference_mode():  # type: ignore[operator]
+        features = model(input_tensor)
+    vector = features.detach().cpu().numpy().astype(np.float32)
+    vector = vector.reshape(-1)
+    if vector.size != EMBED_DIM:
+        logger.debug("Unexpected embedding size: %s", vector.size)
+        resized = np.zeros(EMBED_DIM, dtype=np.float32)
+        resized[: min(EMBED_DIM, vector.size)] = vector[:EMBED_DIM]
+        vector = resized
+    norm = np.linalg.norm(vector)
+    if norm > 0:
+        vector = vector / norm
+    return vector.astype(np.float32, copy=False)

--- a/pill-app/src/indexer.py
+++ b/pill-app/src/indexer.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+"""Utilities for computing similarity between embedding samples."""
+
+import logging
+from typing import Iterable, Mapping, Sequence
+
+import numpy as np
+
+try:  # pragma: no cover - optional dependency
+    import faiss  # type: ignore[import]
+except Exception:  # pragma: no cover - executed when faiss is absent
+    faiss = None  # type: ignore[assignment]
+
+from . import embed
+
+logger = logging.getLogger(__name__)
+
+
+def _extract_vectors(samples: Sequence[Mapping[str, object]] | Iterable[Mapping[str, object]]) -> np.ndarray:
+    """Convert stored samples to a matrix of embeddings."""
+
+    if not isinstance(samples, Sequence):
+        samples = list(samples)
+    vectors: list[np.ndarray] = []
+    for sample in samples:
+        raw = sample.get("embed")
+        if raw is None:
+            continue
+        if isinstance(raw, memoryview):  # pragma: no branch - depends on sqlite version
+            raw = raw.tobytes()
+        if isinstance(raw, bytes):
+            vector = np.frombuffer(raw, dtype=np.float32)
+        else:
+            vector = np.asarray(raw, dtype=np.float32)
+        if vector.size != embed.EMBED_DIM:
+            logger.debug("Skipping sample with unexpected dimensionality: %s", vector.size)
+            continue
+        vectors.append(np.array(vector, dtype=np.float32, copy=True))
+    if not vectors:
+        return np.empty((0, embed.EMBED_DIM), dtype=np.float32)
+    return np.vstack(vectors)
+
+
+def _mean_nearest_similarity(source: np.ndarray, target: np.ndarray) -> float:
+    if source.size == 0 or target.size == 0:
+        return 0.0
+    source = np.ascontiguousarray(source, dtype=np.float32)
+    target = np.ascontiguousarray(target, dtype=np.float32)
+
+    if faiss is not None:
+        index = faiss.IndexFlatIP(embed.EMBED_DIM)
+        index.add(target)
+        distances, _ = index.search(source, 1)
+        return float(distances.mean())
+
+    similarities = source @ target.T
+    if similarities.size == 0:
+        return 0.0
+    max_sim = similarities.max(axis=1)
+    return float(np.mean(max_sim))
+
+
+def mean_nearest_similarity(
+    samples_a: Sequence[Mapping[str, object]] | Iterable[Mapping[str, object]],
+    samples_b: Sequence[Mapping[str, object]] | Iterable[Mapping[str, object]],
+) -> float:
+    """Compute the symmetric mean nearest-neighbour similarity between two bags."""
+
+    vectors_a = _extract_vectors(samples_a)
+    vectors_b = _extract_vectors(samples_b)
+
+    score_ab = _mean_nearest_similarity(vectors_a, vectors_b)
+    score_ba = _mean_nearest_similarity(vectors_b, vectors_a)
+
+    if vectors_a.size == 0 and vectors_b.size == 0:
+        return 0.0
+    if vectors_a.size == 0:
+        return score_ba
+    if vectors_b.size == 0:
+        return score_ab
+    return float((score_ab + score_ba) / 2.0)

--- a/pill-app/src/schemas.py
+++ b/pill-app/src/schemas.py
@@ -78,6 +78,7 @@ class Comparison(BaseModel):
     score_shape: float
     score_count: float
     score_size: float
+    score_embed: float = 0.0
     s_total: float
     decision: str
     preview_path: Optional[str] = None

--- a/pill-app/tests/test_api.py
+++ b/pill-app/tests/test_api.py
@@ -106,6 +106,14 @@ def test_get_image_with_detections() -> None:
     assert "unrecognized_regions" in data
     assert data["message"] is None or isinstance(data["message"], str)
 
+    samples = store.list_samples_for_bag(bag_id)
+    assert samples, "embedding samples should be stored"
+    first_embed = samples[0]["embed"]
+    if isinstance(first_embed, memoryview):
+        first_embed = first_embed.tobytes()
+    assert isinstance(first_embed, (bytes, bytearray))
+    assert len(first_embed) == 4 * 512
+
 
 def test_compare_endpoint_records_comparison() -> None:
     bag_a = client.post("/api/bags", json={"label": "A"})
@@ -134,6 +142,7 @@ def test_compare_endpoint_records_comparison() -> None:
     assert data["decision"] == "bag_a"
     assert data["preview_path"] == "data/outputs/sample.png"
     assert data["s_total"] == expected_total
+    assert data["score_embed"] == pytest.approx(0.0, abs=1e-6)
 
     stored = store.get_comparison(data["id"])
     assert stored is not None


### PR DESCRIPTION
## Summary
- add a ResNet18 embedding helper and FAISS-based similarity utilities
- persist detection embeddings and expose an averaged embedding score in the comparison API
- extend store schema and tests to cover embedding samples and the new score

## Testing
- pytest *(fails: missing FastAPI dependency and dependencies cannot be installed in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cba64107c0832cb592aa7c444b91bd